### PR TITLE
Now encode relative paths as URIs (Escape space as %20, etc)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,8 @@
 * Missed adding the commit command to the entry points. This means you'd have to run another command first. This is now fixed.
 
 ## 0.3.3 - Added notifications
+
+## 0.3.4 - Escape Whitespace
+
+* Whitespace In Paths were previously not escaped, breaking links when repositories has spaces in some filenames
+  this is now fixed

--- a/lib/git-links.coffee
+++ b/lib/git-links.coffee
@@ -37,6 +37,7 @@ module.exports = GitLinks =
           self.git(['rev-parse', '--show-toplevel'], (code, stdout, errors) ->
             gitDirectory = stdout.trim()
             relativePath = filePath.replace(gitDirectory, '')
+            relativePath = encodeURI(relativePath)
             link = repo + '/blob/' + commitHash + relativePath + '#L' + line
             atom.clipboard.write(link)
             atom.notifications.addInfo('Copied link for current line to clipboard', detail: link)
@@ -63,6 +64,7 @@ module.exports = GitLinks =
           self.git(['rev-parse', '--show-toplevel'], (code, stdout, errors) ->
             gitDirectory = stdout.trim()
             relativePath = filePath.replace(gitDirectory, '')
+            relativePath = encodeURI(relativePath)
             link = repo + '/blob/' + commitHash + relativePath
             atom.clipboard.write(link)
             atom.notifications.addInfo('Copied link for current file to clipboard', detail: link)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "git-links-plus",
   "main": "./lib/git-links",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Get a link to any code hosted in github. Previously maintained by calebmeyer",
   "keywords": [
     "git",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "git-links",
+  "name": "git-links-plus",
   "main": "./lib/git-links",
-  "version": "0.3.3",
-  "description": "Get a link to any code hosted in github",
+  "version": "0.3.4",
+  "description": "Get a link to any code hosted in github. Previously maintained by calebmeyer",
   "keywords": [
     "git",
     "link",
@@ -15,7 +15,7 @@
       "git-links:copy-absolute-link-for-current-commit"
     ]
   },
-  "repository": "https://github.com/calebmeyer/git-links",
+  "repository": "https://github.com/mstr3336/git-links",
   "license": "MIT",
   "engines": {
     "atom": ">=1.0.0 <2.0.0"


### PR DESCRIPTION
This allows the tool to work as normal when there is a space in the relative path of the file to be linked.